### PR TITLE
add clarification to github actions to only test on main branch.

### DIFF
--- a/.github/actions.yaml
+++ b/.github/actions.yaml
@@ -1,5 +1,6 @@
 name: CI Build and Test
 on: [push, pull_request]
+  - branches: [main]
 
 env:
   RUST_BACKTRACE: full

--- a/.github/actions.yaml
+++ b/.github/actions.yaml
@@ -11,36 +11,43 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11, macos-14]
-        rust: [stable, beta, nightly]
-      fail-fast: true
+        os: [ubuntu-latest, macos-13, macos-14]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
-            ~/.cargo/bin
+            ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
+          override: true
       - run: cargo build --release
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: binary-${{ matrix.os }}
-          path: target/release/
+          path: target/release/libawry.rlib
 
   test:
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11, macos-14]
+        os: [ubuntu-latest, macos-13, macos-14]
     steps:
       - uses: actions/checkout@v2
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: binary-${{ matrix.os }}
+          path: target/release/
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          override: true
       - run: cargo test


### PR DESCRIPTION
Now, pull requests to branches other than main don't have to wait for all the tests. You should run them manually on other branches, of course, but it's only a forced automation on the main.